### PR TITLE
Update mod2.rst

### DIFF
--- a/docs/mod2.rst
+++ b/docs/mod2.rst
@@ -173,7 +173,7 @@ node in the table is the output of an elmentary function, whose derivative we ca
           - 4
         * - :math:`v_4`
           - :math:`-2v_3`
-          - 1
+          - -1
           - :math:`-2\dot{v_3}`
           - -8
         * - :math:`v_5`


### PR DESCRIPTION
What: small typo fix.

Where: Section `original demo` for trace corresponding to `v4`.

Justification: The function for `v4` is `-2v3`. The value for `v3` is `1/2`, hence `v4` becomes `-1`. This is also in line with the value of `v5` in the text which is given as `1/e`, only possible if `v4` is equal to `-1`.